### PR TITLE
Improve canvas scaling UX

### DIFF
--- a/index.html
+++ b/index.html
@@ -423,9 +423,12 @@
           <p style="color: #ffd700;">
             Changing the scale will affect layout and may disrupt existing placements.
           </p>
-          <label for="canvasScale">Canvas Scale (0.1 - 5.0):</label>
-          <input type="number" id="canvasScale" value="1" step="0.1" min="0.1" max="5" />
-          <button id="applyScaleBtn">Apply Scale</button>
+          <label for="canvasScale">Canvas Scale:</label>
+          <div class="scale-control">
+            <input type="range" id="canvasScale" value="1" step="0.1" min="0.5" max="2" />
+            <span id="scaleDisplay">1</span>
+            <button id="resetScaleBtn" title="Revert Scale">↺</button>
+          </div>
           <p style="margin-top: 1rem; border-top: 1px solid #999; padding-top: 1rem;">
             <strong>Export IDs</strong>
           </p>
@@ -459,11 +462,12 @@
         </div>
 
         <!-- Our SVG Canvas -->
-        <svg 
-          id="canvasSVG" 
-          width="1046.5" 
+        <svg
+          id="canvasSVG"
+          width="1046.5"
           height="500"
-          xmlns="http://www.w3.org/2000/svg" 
+          viewBox="0 0 1046.5 500"
+          xmlns="http://www.w3.org/2000/svg"
           xmlns:xlink="http://www.w3.org/1999/xlink"
         >
           <!-- Embed styling in defs so it’s included in exported SVG -->

--- a/style.css
+++ b/style.css
@@ -172,6 +172,21 @@ body {
   width: 60px; /* shrink to fit same line */
 }
 
+/* Scale slider layout */
+.scale-control {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0.5rem 0;
+}
+.scale-control input[type="range"] {
+  flex: 1;
+}
+.scale-control button {
+  padding: 0 0.5rem;
+  cursor: pointer;
+}
+
 /* Slight highlight for the Zone Name block */
 .zone-name-block {
   background-color: #1b4c88;


### PR DESCRIPTION
## Summary
- replace numeric canvas scale input with range slider
- add reset button and store scale on SVG element
- adjust drag/resize logic to respect current scale
- save scale in exported SVG and restore during import
- tweak styling for new scale controls
- **fix canvas scaling using viewBox**

## Testing
- `node --check script.js`
