### PR TITLE
Add dock/spot editing via context menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -665,6 +665,13 @@
       <li data-action="send-backward">Send Backward</li>
       <li data-action="send-back">Send to Back</li>
       <li data-action="delete">Delete</li>
+      <li id="contextAdd" data-action="add-items" style="color: #0f0">
+        ⊕ Add Spots
+      </li>
+      <li id="contextRemove" data-action="remove-items" style="color: #f55">
+        ⊖ Remove Spots
+      </li>
+      <li id="contextEditFirst" data-action="edit-first">Edit First Number</li>
     </ul>
 
     <script src="script.js"></script>

--- a/style.css
+++ b/style.css
@@ -542,6 +542,16 @@ input:checked + .slider:before {
   stroke-width: 2;
 }
 
+.highlight-add {
+  stroke: yellow;
+  stroke-width: 2;
+}
+
+.highlight-remove {
+  stroke: red;
+  stroke-width: 2;
+}
+
 /* =========================
    LAYERS SIDEBAR
 ========================= */


### PR DESCRIPTION
## Summary
- extend context menu with Add/Remove options and Edit First Number
- highlight additions in yellow and removals in red
- update counters and zone counts when editing

## Testing
- `npx prettier -w index.html script.js style.css`
- `npx prettier -c index.html script.js style.css`
