### PR TITLE
Fix spot group hitbox growth

### DIFF
--- a/script.js
+++ b/script.js
@@ -3120,7 +3120,8 @@
     const firstRect = spots[0].querySelector("rect");
     const spotW = parseFloat(firstRect.getAttribute("width"));
     const spotH = parseFloat(firstRect.getAttribute("height"));
-    const orientation = spotW > spotH ? "vertical" : "horizontal";
+    let orientation = group.getAttribute("data-orientation");
+    if (!orientation) orientation = spotW > spotH ? "vertical" : "horizontal";
 
     if (group.getAttribute("data-zone") === "yes") {
       let maxX = 0;
@@ -3204,7 +3205,9 @@
     const spotH = parseFloat(firstRect.getAttribute("height"));
     let zoneW = parseFloat(group.getAttribute("data-w"));
     let zoneH = parseFloat(group.getAttribute("data-h"));
-    const orientation = zoneH - 18.2 > zoneW ? "vertical" : "horizontal";
+    let orientation = group.getAttribute("data-orientation");
+    if (!orientation)
+      orientation = zoneH - 18.2 > zoneW ? "vertical" : "horizontal";
     let columns = Math.round(zoneW / spotW);
     let rows = Math.round((zoneH - 18.2) / spotH);
 
@@ -3280,13 +3283,14 @@
     const firstRect = spots[0].querySelector("rect");
     const spotW = parseFloat(firstRect.getAttribute("width"));
     const spotH = parseFloat(firstRect.getAttribute("height"));
-    const orientation = group.getAttribute("data-orientation")
-      || (
+    let orientation = group.getAttribute("data-orientation");
+    if (!orientation) {
+      orientation =
         parseFloat(group.getAttribute("data-w")) >
         parseFloat(group.getAttribute("data-h"))
-          ? "horizontal"
-          : "vertical"
-        ); 
+          ? "vertical"
+          : "horizontal";
+    }
     const firstLabel = group.querySelector(".spot-label");
     const hasLabels = !!firstLabel;
     const labelLocation = hasLabels
@@ -3480,7 +3484,7 @@
       const ln = lines[lines.length - 1 - i];
       if (ln) ln.remove();
     }
- 
+
     adjustGroupSize(group);
     updateCounters();
     rebuildLayersList();
@@ -3488,11 +3492,14 @@
     const firstRect = spots[0].querySelector("rect");
     const spotW = parseFloat(firstRect.getAttribute("width"));
     const spotH = parseFloat(firstRect.getAttribute("height"));
-    const orientation =
-      parseFloat(group.getAttribute("data-w")) >
-      parseFloat(group.getAttribute("data-h"))
-        ? "vertical"
-        : "horizontal";
+    let orientation = group.getAttribute("data-orientation");
+    if (!orientation) {
+      orientation =
+        parseFloat(group.getAttribute("data-w")) >
+        parseFloat(group.getAttribute("data-h"))
+          ? "vertical"
+          : "horizontal";
+    }
     const remaining = spots.length - removeCount;
     if (orientation === "vertical") {
       group.setAttribute("data-w", Math.max(remaining, 1) * spotW);
@@ -3535,7 +3542,8 @@
     if (!firstRect) return;
     const spotW = parseFloat(firstRect.getAttribute("width"));
     const spotH = parseFloat(firstRect.getAttribute("height"));
-    const orientation = spotW > spotH ? "vertical" : "horizontal";
+    let orientation = group.getAttribute("data-orientation");
+    if (!orientation) orientation = spotW > spotH ? "vertical" : "horizontal";
     const labelLocation = inferLabelLocation(firstLabel, orientation);
     const rotationMode = firstLabel.getAttribute("transform")
       ? "90"


### PR DESCRIPTION
## Summary
- ensure add/remove items keeps correct orientation
- fix `adjustGroupSize` orientation calculation
- preserve orientation in editing first numbers
- correct zone orientation when adding new spots

## Testing
- `npx prettier -c index.html script.js style.css`
