### PR TITLE
Add universal undo/redo functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,6 +42,24 @@
               />
             </svg>
           </button>
+          <button
+            id="redoBtn"
+            title="Redo (SHIFT+CTRL/CMD-Z)"
+            aria-label="Redo"
+          >
+            <!-- Redo Icon (SVG flipped) -->
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+              class="redo-icon"
+            >
+              <path
+                d="M12 5V1L8 5l4 4V6c3.31 0 6 2.69 6 6s-2.69 6-6 6-6-2.69-6-6H4c0 4.42 3.58 8 8 8s8-3.58 8-8-3.58-8-8-8z"
+              />
+            </svg>
+          </button>
           <span id="totalSpots">Spots: 0</span>
           <span id="totalDocks">Docks: 0</span>
         </div>

--- a/style.css
+++ b/style.css
@@ -753,3 +753,34 @@ input:checked + .slider:before {
   opacity: 0.5;
   cursor: not-allowed;
 }
+
+/* Redo Button Styling */
+#redoBtn {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 0.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition:
+    background-color 0.2s,
+    transform 0.2s;
+  border-radius: 4px;
+}
+
+#redoBtn:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+  transform: scale(1.05);
+}
+
+#redoBtn svg {
+  fill: #eeeeee;
+  width: 16px;
+  height: 16px;
+  transform: scaleX(-1);
+}
+#redoBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}


### PR DESCRIPTION
## Summary
- implement redo button and keyboard shortcut
- broaden undo stack to handle group edits and layer reorders
- store translations when deleting from context menu
- add helper functions for layer ordering and group change tracking

## Testing
- `npx prettier -w index.html script.js style.css`
- `npx prettier -c index.html script.js style.css`
