### PR TITLE
Fix undo after context menu delete

### DIFF
--- a/script.js
+++ b/script.js
@@ -3247,7 +3247,11 @@
       editFirstNumber(contextTarget);
     }
     const afterOrder = getLayerOrder();
-    if (JSON.stringify(beforeOrder) !== JSON.stringify(afterOrder)) {
+    if (
+      contextTarget &&
+      contextTarget.isConnected &&
+      JSON.stringify(beforeOrder) !== JSON.stringify(afterOrder)
+    ) {
       pushUndoAction({
         type: "reorder",
         before: beforeOrder,


### PR DESCRIPTION
## Summary
- prevent adding a reorder undo action when the element is deleted via context menu

## Testing
- `npx prettier -c index.html script.js style.css`