### PR TITLE
Fix undo for layer reordering

### DIFF
--- a/script.js
+++ b/script.js
@@ -3108,15 +3108,12 @@
   function applyLayerOrder(order) {
     const scalable = document.getElementById("scalableContent");
     const lost = scalable.querySelector("g.lostTrailer");
-    order
-      .slice()
-      .reverse()
-      .forEach((id) => {
-        const g = scalable.querySelector(`[data-layer-id="${id}"]`);
-        if (g && g !== lost) {
-          scalable.insertBefore(g, lost || null);
-        }
-      });
+    order.forEach((id) => {
+      const g = scalable.querySelector(`[data-layer-id="${id}"]`);
+      if (g && g !== lost) {
+        scalable.insertBefore(g, lost || null);
+      }
+    });
     ensureLostBoxOnTop();
     rebuildLayersList();
   }


### PR DESCRIPTION
## Summary
- correct `applyLayerOrder` to maintain provided order

## Testing
- `npx prettier -c index.html script.js style.css`