### PR TITLE
Add alert for trash can click

### DIFF
--- a/script.js
+++ b/script.js
@@ -929,6 +929,10 @@
     hideContextMenu.style.top = e.clientY + "px";
   });
 
+  trashCan.addEventListener("click", () => {
+    alert("Drag an item to the trash can to delete it");
+  });
+
   // -------------------------------
   // Zones Table
   // -------------------------------


### PR DESCRIPTION
## Summary
- add click listener to trash can that informs users to drag items
- run Prettier

## Testing
- `npx prettier -c index.html script.js style.css`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_683b8c393870832f9f668e158a3b80e9