### PR TITLE
Add overlay hint for trash can click

### DIFF
--- a/script.js
+++ b/script.js
@@ -929,6 +929,10 @@
     hideContextMenu.style.top = e.clientY + "px";
   });
 
+  trashCan.addEventListener("click", () => {
+    showTrashInstruction();
+  });
+
   // -------------------------------
   // Zones Table
   // -------------------------------
@@ -1533,6 +1537,20 @@
       onYes();
     });
     overlay.querySelector("#confirmNo").addEventListener("click", () => {
+      document.body.removeChild(overlay);
+    });
+  }
+
+  function showTrashInstruction() {
+    const overlay = document.createElement("div");
+    overlay.className = "confirm-overlay";
+    const box = document.createElement("div");
+    box.className = "confirm-box";
+    box.innerHTML =
+      '<p>Drag an item to the trash can to delete it</p><div class="confirm-buttons"><button id="trashOk">OK</button></div>';
+    overlay.appendChild(box);
+    document.body.appendChild(overlay);
+    overlay.querySelector("#trashOk").addEventListener("click", () => {
       document.body.removeChild(overlay);
     });
   }


### PR DESCRIPTION
## Summary
- show a styled overlay when the trash can is clicked

## Testing
- `npx prettier -c index.html script.js style.css`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_683b8c393870832f9f668e158a3b80e9