### PR TITLE
Add rotate button for selected elements

### DIFF
--- a/style.css
+++ b/style.css
@@ -867,3 +867,15 @@ g.selected rect[data-role="hitbox"] {
   stroke-width: 2;
   fill: rgba(255, 152, 0, 0.2);
 }
+
+/* Rotate button */
+#rotateBtn circle {
+  fill: rgba(0, 0, 0, 0.6);
+  stroke: #fff;
+  stroke-width: 1;
+}
+#rotateBtn path {
+  stroke: #fff;
+  stroke-width: 1.5;
+  fill: none;
+}


### PR DESCRIPTION
## Summary
- add context-aware rotate button on canvas
- rotate elements by adjusting orientation and dimensions
- reposition labels and dock triangles when rotating
- style rotate button with dark semi-transparent background

## Testing
- `npx prettier -w index.html script.js style.css`

------
https://chatgpt.com/codex/tasks/task_b_683b9de43b54832f899bf6dffea3b0cb