### PR TITLE
Fix rotate button click handling

### DIFF
--- a/script.js
+++ b/script.js
@@ -1328,6 +1328,12 @@
   let isResizing = false;
 
   canvasSVG.addEventListener("mousedown", (e) => {
+    if (e.target.closest("#rotateBtn")) {
+      e.stopPropagation();
+      e.preventDefault();
+      return;
+    }
+
     const target = e.target;
     const group = target.closest('g[data-type="draggable"]');
     const additive = e.shiftKey || e.metaKey;


### PR DESCRIPTION
## Summary
- prevent the canvas mousedown handler from removing the rotate button when it is clicked

## Testing
- `npx prettier -c index.html script.js style.css`

------
https://chatgpt.com/codex/tasks/task_b_683ba2684e3c832f8f2da166cf628620