### PR TITLE
Fix rotate button svg scale

### DIFF
--- a/script.js
+++ b/script.js
@@ -945,11 +945,16 @@
   rotatePath.setAttribute("fill", "none");
   rotatePath.setAttribute("stroke", "#fff");
   rotatePath.setAttribute("stroke-width", "2");
-  rotatePath.setAttribute("transform", "scale(1.2)");
   rotatePath.setAttribute("stroke-linecap", "round");
   rotatePath.setAttribute("stroke-linejoin", "round");
+  const rotateArrowGroup = document.createElementNS(
+    "http://www.w3.org/2000/svg",
+    "g",
+  );
+  rotateArrowGroup.setAttribute("transform", "scale(1.2)");
+  rotateArrowGroup.appendChild(rotatePath);
   rotateBtn.appendChild(rotateBg);
-  rotateBtn.appendChild(rotatePath);
+  rotateBtn.appendChild(rotateArrowGroup);
 
   rotateBtn.addEventListener("click", () => {
     if (selectedElements.size !== 1) return;


### PR DESCRIPTION
## Summary
- wrap rotate arrow path in a scaling `<g>`

## Testing
- `npx prettier -w index.html script.js style.css`
- `npx prettier -c index.html script.js style.css`


------
https://chatgpt.com/codex/tasks/task_b_683ba94c38ec832facd93a8e11c4f2bf