### PR TITLE
Modernize rotate button style

### DIFF
--- a/index.html
+++ b/index.html
@@ -568,15 +568,28 @@
             <img src="https://i.imgur.com/PXejZqX.png" alt="trash can" />
           </div>
 
-          <button
-            id="rotateBtn"
-            aria-label="Rotate"
-            title="Rotate"
-            style="position: absolute; display: none"
-          >
-            <svg width="32" height="32" viewBox="0 0 32 32">
-              <circle cx="16" cy="16" r="14" />
-              <path d="M11 11 L21 11 L21 21 M21 11 A9 9 0 1 1 11 21" />
+          <button id="rotateBtn" aria-label="Rotate" title="Rotate">
+            <svg
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M12 4v1.5a6.5 6.5 0 1 1-6.487 7.154"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+              <path
+                d="M8 7 L12 4 L16 7"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
             </svg>
           </button>
 

--- a/script.js
+++ b/script.js
@@ -924,13 +924,13 @@
   // Rotate button (HTML button overlay)
   const rotateBtn = document.getElementById("rotateBtn");
   rotateBtn.setAttribute("data-export-ignore", "true");
-  rotateBtn.style.display = "none";
 
   rotateBtn.addEventListener("click", () => {
     if (selectedElements.size !== 1) return;
     const el = Array.from(selectedElements)[0];
     rotateGroup(el);
     updateRotateButton();
+    rotateBtn.blur();
   });
 
   // Selection state
@@ -992,20 +992,19 @@
   }
 
   function updateRotateButton() {
-    rotateBtn.style.display = "none";
+    rotateBtn.classList.remove("show");
     if (selectedElements.size !== 1) return;
     const el = Array.from(selectedElements)[0];
     const bbox = el.getBBox();
     const matrix = el.getCTM();
     if (!matrix) return;
     const pt = canvasSVG.createSVGPoint();
-    pt.x = bbox.x + bbox.width;
-    pt.y = bbox.y;
+    pt.x = bbox.x + bbox.width + 4;
+    pt.y = bbox.y - 4;
     const global = pt.matrixTransform(matrix);
-    rotateBtn.style.left = `${global.x + 4}px`;
-    rotateBtn.style.top = `${global.y - 4}px`;
-    rotateBtn.style.transform = "translate(-50%, -50%)";
-    rotateBtn.style.display = "block";
+    rotateBtn.style.left = `${global.x}px`;
+    rotateBtn.style.top = `${global.y}px`;
+    rotateBtn.classList.add("show");
   }
 
   trashCan.addEventListener("contextmenu", (e) => {
@@ -1320,7 +1319,7 @@
     const group = target.closest('g[data-type="draggable"]');
     const additive = e.shiftKey || e.metaKey;
 
-    rotateBtn.style.display = "none";
+    rotateBtn.classList.remove("show");
 
     if (!group) {
       // Start marquee selection

--- a/style.css
+++ b/style.css
@@ -871,44 +871,39 @@ g.selected rect[data-role="hitbox"] {
 /* Rotate button */
 #rotateBtn {
   position: absolute;
-  background: transparent;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  background: rgba(255, 255, 255, 0);
   border: none;
-  padding: 4px;
   cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 4px;
+  outline: none;
+  opacity: 0;
+  transform: scale(0.8);
   transition:
-    background-color 0.2s,
-    transform 0.2s;
+    opacity 0.15s ease,
+    background 0.15s ease,
+    transform 0.15s ease;
+  pointer-events: none;
+  color: rgba(255, 255, 255, 0.9);
 }
-#rotateBtn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-#rotateBtn circle {
-  fill: #14335d;
-  stroke: #fff;
-  stroke-width: 1;
-}
-#rotateBtn:hover circle,
-#rotateBtn:focus circle {
-  fill: #1b4c88;
-}
-
-#rotateBtn path {
-  stroke: #fff;
-  stroke-width: 2.5;
+#rotateBtn svg path {
+  stroke: currentColor;
+  stroke-width: 2;
   fill: none;
-  transform-origin: center;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
-
-#rotateBtn:hover {
-  background-color: rgba(255, 255, 255, 0.1);
-  transform: scale(1.05);
+#rotateBtn.show {
+  opacity: 1;
+  transform: scale(1);
+  pointer-events: auto;
 }
+#rotateBtn:hover,
 #rotateBtn:focus {
-  outline: 2px solid rgba(255, 255, 255, 0.6);
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 4px;
+}
+#rotateBtn:active {
+  background: rgba(255, 255, 255, 0.3);
 }


### PR DESCRIPTION
## Summary
- revamp rotate button markup with lightweight SVG
- add modern ghost-style CSS for the rotate handle
- reposition rotate button 4px outside selections and fade in/out
- blur rotate button on click so it never stays active

## Testing
- `npx prettier -c index.html script.js style.css`

------
https://chatgpt.com/codex/tasks/task_b_683bb02d57a0832f9bc994159b1c469d