### PR TITLE
Fix rotate button updates on drag and undo/redo

### DIFF
--- a/script.js
+++ b/script.js
@@ -75,10 +75,15 @@
         element.setAttribute("transform", `translate(${oldX},${oldY})`);
         element.setAttribute("data-type", "draggable");
         element.setAttribute("style", "cursor: move;");
+        // Remove any “selected” class on the clone, and clear from internal set
+        element.classList.remove("selected");
+        selectedElements.delete(element);
         rebuildZonesTable();
         updateCounters();
         ensureLostBoxOnTop();
         rebuildLayersList();
+        // Recalc/hide rotate button now that the clone is reinserted
+        updateRotateButton();
         redoStack.push({
           type: "delete",
           element,
@@ -117,6 +122,8 @@
     }
     updateUndoButtonState();
     updateRedoButtonState();
+    // Immediately reposition or hide the rotate button after undo
+    updateRotateButton();
   }
 
   function redoLastAction() {
@@ -171,6 +178,8 @@
     }
     updateUndoButtonState();
     updateRedoButtonState();
+    // Immediately reposition or hide the rotate button after redo
+    updateRotateButton();
   }
 
   // -------------------------------
@@ -1411,6 +1420,8 @@
 
     if (!currentElement) return;
     e.preventDefault();
+    // As soon as we start dragging, hide the rotate button
+    rotateBtn.classList.remove("show");
 
     if (isResizing) {
       const isLabel = !!currentElement.querySelector(
@@ -1701,6 +1712,8 @@
     updateSelectionIndicators();
     rebuildZonesTable();
     updateCounters();
+    // Force the Layers sidebar to update right away
+    rebuildLayersList();
   }
 
   function animateTrash() {


### PR DESCRIPTION
## Summary
- hide rotate button when dragging begins
- refresh rotate button after undo/redo
- clear `selected` class on undo-delete
- update layers list immediately on group delete

## Testing
- `npx prettier -c script.js`

------
https://chatgpt.com/codex/tasks/task_b_683d5947b4dc832f96f28ddcecddbacc